### PR TITLE
Update fabric.mod.json

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -32,7 +32,7 @@
   ],
   "depends": {
     "java": ">=17",
-    "minecraft": "${minecraft_version}",
+    "minecraft": ">=${minecraft_version}",
     "fabric-api": ">=${fabric_version}",
     "fabricloader": ">=${loader_version}",
     "cloth-config2": ">=${cloth_config_version}"


### PR DESCRIPTION
I noticed that DungeonZ can't run in 1.20.1 because the minecraft version in fabric.mod.json is 1.20 instead of >=1.20.So I did it for 1.20.1 compatibility.