### PR TITLE
fixed out of bounds error in DungeonCompassScreen

### DIFF
--- a/src/main/java/net/dungeonz/item/screen/DungeonCompassScreen.java
+++ b/src/main/java/net/dungeonz/item/screen/DungeonCompassScreen.java
@@ -210,7 +210,8 @@ public class DungeonCompassScreen extends Screen {
         }
 
         public void renderTooltip(DrawContext context, int mouseX, int mouseY) {
-            if (this.hovered) {
+            if (this.hovered
+                    && this.index + DungeonCompassScreen.this.indexStartOffset < DungeonCompassScreen.this.dungeonIds.size()) {
                 Text text = Text.translatable("dungeon." + DungeonCompassScreen.this.dungeonIds.get(this.index + DungeonCompassScreen.this.indexStartOffset));
                 if (client.textRenderer.getWidth(text) > 78) {
                     context.drawTooltip(textRenderer, text, mouseX, mouseY);


### PR DESCRIPTION
Minecraft crashes when DungeonCompass is used (see below).
This PR fixes this issue.

```
---- Minecraft Crash Report ----
// You should try our sister game, Minceraft!

Time: 2025-10-22 10:21:21
Description: Rendering screen

java.lang.IndexOutOfBoundsException: Index 3 out of bounds for length 2
	at java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:100)
	at java.base/jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:106)
	at java.base/jdk.internal.util.Preconditions.checkIndex(Preconditions.java:302)
	at java.base/java.util.Objects.checkIndex(Objects.java:385)
	at java.base/java.util.ArrayList.get(ArrayList.java:427)
	at knot//net.dungeonz.item.screen.DungeonCompassScreen$WidgetButtonPage.renderTooltip(DungeonCompassScreen.java:214)
	at knot//net.dungeonz.item.screen.DungeonCompassScreen.method_25394(DungeonCompassScreen.java:109)
	at knot//net.minecraft.class_437.method_47413(class_437.java:110)
	at knot//net.minecraft.class_757.mixinextras$bridge$method_47413$281(class_757.java)
	at knot//net.minecraft.class_757.wrapOperation$dcm000$fancymenu$wrapRenderScreenFancyMenu(class_757.java:7107)
	at knot//net.minecraft.class_757.mixinextras$bridge$wrapOperation$dcm000$fancymenu$wrapRenderScreenFancyMenu$282(class_757.java)
	at knot//net.minecraft.class_757.wrapOperation$eea000$konkrete$wrapRenderScreenKonkrete(class_757.java:10628)
	at knot//net.minecraft.class_757.method_3192(class_757.java:945)
	at knot//net.minecraft.class_310.method_1523(class_310.java:1219)
	at knot//net.minecraft.class_310.method_1514(class_310.java:802)
	at knot//net.minecraft.client.main.Main.main(Main.java:250)
	at net.fabricmc.loader.impl.game.minecraft.MinecraftGameProvider.launch(MinecraftGameProvider.java:480)
	at net.fabricmc.loader.impl.launch.knot.Knot.launch(Knot.java:74)
	at net.fabricmc.loader.impl.launch.knot.KnotClient.main(KnotClient.java:23)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.multimc.onesix.OneSixLauncher.launchWithMainClass(OneSixLauncher.java:243)
	at org.multimc.onesix.OneSixLauncher.launch(OneSixLauncher.java:278)
	at org.multimc.EntryPoint.listen(EntryPoint.java:143)
	at org.multimc.EntryPoint.main(EntryPoint.java:34)


A detailed walkthrough of the error, its code path and all known details is as follows:
---------------------------------------------------------------------------------------

-- Head --
Thread: Render thread
Stacktrace:
	at java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:100)
	at java.base/jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:106)
	at java.base/jdk.internal.util.Preconditions.checkIndex(Preconditions.java:302)
	at java.base/java.util.Objects.checkIndex(Objects.java:385)
	at java.base/java.util.ArrayList.get(ArrayList.java:427)
	at knot//net.dungeonz.item.screen.DungeonCompassScreen$WidgetButtonPage.renderTooltip(DungeonCompassScreen.java:214)
	at knot//net.dungeonz.item.screen.DungeonCompassScreen.method_25394(DungeonCompassScreen.java:109)
	at knot//net.minecraft.class_437.method_47413(class_437.java:110)
	at knot//net.minecraft.class_757.mixinextras$bridge$method_47413$281(class_757.java)
	at knot//net.minecraft.class_757.wrapOperation$dcm000$fancymenu$wrapRenderScreenFancyMenu(class_757.java:7107)
	at knot//net.minecraft.class_757.mixinextras$bridge$wrapOperation$dcm000$fancymenu$wrapRenderScreenFancyMenu$282(class_757.java)
	at knot//net.minecraft.class_757.wrapOperation$eea000$konkrete$wrapRenderScreenKonkrete(class_757.java:10628)

-- Screen render details --
Details:
	Screen name: net.dungeonz.item.screen.DungeonCompassScreen
	Mouse location: Scaled: (427, 240). Absolute: (1280.000000, 720.000000)
	Screen size: Scaled: (854, 480). Absolute: (2560, 1440). Scale factor of 3.000000
Stacktrace:
	at knot//net.minecraft.class_757.method_3192(class_757.java:945)
	at knot//net.minecraft.class_310.method_1523(class_310.java:1219)
	at knot//net.minecraft.class_310.method_1514(class_310.java:802)
	at knot//net.minecraft.client.main.Main.main(Main.java:250)
	at net.fabricmc.loader.impl.game.minecraft.MinecraftGameProvider.launch(MinecraftGameProvider.java:480)
	at net.fabricmc.loader.impl.launch.knot.Knot.launch(Knot.java:74)
	at net.fabricmc.loader.impl.launch.knot.KnotClient.main(KnotClient.java:23)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.multimc.onesix.OneSixLauncher.launchWithMainClass(OneSixLauncher.java:243)
	at org.multimc.onesix.OneSixLauncher.launch(OneSixLauncher.java:278)
	at org.multimc.EntryPoint.listen(EntryPoint.java:143)
	at org.multimc.EntryPoint.main(EntryPoint.java:34)
```