### PR TITLE
Fix boss chest loot table files

### DIFF
--- a/src/main/resources/data/dungeonz/loot_table/chests/dark_dungeon_easy_boss_loot.json
+++ b/src/main/resources/data/dungeonz/loot_table/chests/dark_dungeon_easy_boss_loot.json
@@ -42,8 +42,7 @@
                                 "type": "minecraft:uniform",
                                 "max": 50.0,
                                 "min": 30.0
-                            },
-                            "treasure": true
+                            }
                         }
                     ],
                     "name": "minecraft:iron_sword",
@@ -72,8 +71,7 @@
                                 "type": "minecraft:uniform",
                                 "max": 50.0,
                                 "min": 30.0
-                            },
-                            "treasure": true
+                            }
                         }
                     ],
                     "name": "minecraft:iron_shovel",
@@ -102,8 +100,7 @@
                                 "type": "minecraft:uniform",
                                 "max": 50.0,
                                 "min": 30.0
-                            },
-                            "treasure": true
+                            }
                         }
                     ],
                     "name": "minecraft:iron_pickaxe",
@@ -132,8 +129,7 @@
                                 "type": "minecraft:uniform",
                                 "max": 50.0,
                                 "min": 30.0
-                            },
-                            "treasure": true
+                            }
                         }
                     ],
                     "name": "minecraft:iron_axe",
@@ -162,8 +158,7 @@
                                 "type": "minecraft:uniform",
                                 "max": 50.0,
                                 "min": 30.0
-                            },
-                            "treasure": true
+                            }
                         }
                     ],
                     "name": "minecraft:iron_hoe",
@@ -192,8 +187,7 @@
                                 "type": "minecraft:uniform",
                                 "max": 50.0,
                                 "min": 30.0
-                            },
-                            "treasure": true
+                            }
                         }
                     ],
                     "name": "minecraft:iron_helmet",
@@ -222,8 +216,7 @@
                                 "type": "minecraft:uniform",
                                 "max": 50.0,
                                 "min": 30.0
-                            },
-                            "treasure": true
+                            }
                         }
                     ],
                     "name": "minecraft:iron_chestplate",
@@ -252,8 +245,7 @@
                                 "type": "minecraft:uniform",
                                 "max": 50.0,
                                 "min": 30.0
-                            },
-                            "treasure": true
+                            }
                         }
                     ],
                     "name": "minecraft:iron_leggings",
@@ -282,8 +274,7 @@
                                 "type": "minecraft:uniform",
                                 "max": 50.0,
                                 "min": 30.0
-                            },
-                            "treasure": true
+                            }
                         }
                     ],
                     "name": "minecraft:iron_boots",
@@ -304,8 +295,7 @@
                     "functions": [
                         {
                             "function": "minecraft:enchant_with_levels",
-                            "levels": 30.0,
-                            "treasure": true
+                            "levels": 30.0
                         }
                     ],
                     "name": "minecraft:book"

--- a/src/main/resources/data/dungeonz/loot_table/chests/dark_dungeon_hard_boss_loot.json
+++ b/src/main/resources/data/dungeonz/loot_table/chests/dark_dungeon_hard_boss_loot.json
@@ -38,10 +38,10 @@
                     "weight": 1,
                     "functions": [
                         {
-                            "enchantments": [
+                            "function": "minecraft:enchant_randomly",
+                            "options": [
                                 "minecraft:mending"
-                            ],
-                            "function": "minecraft:enchant_randomly"
+                            ]
                         }
                     ]
                 }
@@ -78,8 +78,7 @@
                                 "type": "minecraft:uniform",
                                 "max": 50.0,
                                 "min": 30.0
-                            },
-                            "treasure": true
+                            }
                         }
                     ],
                     "name": "minecraft:netherite_sword",
@@ -108,8 +107,7 @@
                                 "type": "minecraft:uniform",
                                 "max": 50.0,
                                 "min": 30.0
-                            },
-                            "treasure": true
+                            }
                         }
                     ],
                     "name": "minecraft:netherite_shovel",
@@ -138,8 +136,7 @@
                                 "type": "minecraft:uniform",
                                 "max": 50.0,
                                 "min": 30.0
-                            },
-                            "treasure": true
+                            }
                         }
                     ],
                     "name": "minecraft:netherite_pickaxe",
@@ -168,8 +165,7 @@
                                 "type": "minecraft:uniform",
                                 "max": 50.0,
                                 "min": 30.0
-                            },
-                            "treasure": true
+                            }
                         }
                     ],
                     "name": "minecraft:netherite_axe",
@@ -198,8 +194,7 @@
                                 "type": "minecraft:uniform",
                                 "max": 50.0,
                                 "min": 30.0
-                            },
-                            "treasure": true
+                            }
                         }
                     ],
                     "name": "minecraft:netherite_hoe",
@@ -228,8 +223,7 @@
                                 "type": "minecraft:uniform",
                                 "max": 50.0,
                                 "min": 30.0
-                            },
-                            "treasure": true
+                            }
                         }
                     ],
                     "name": "minecraft:netherite_helmet",
@@ -258,8 +252,7 @@
                                 "type": "minecraft:uniform",
                                 "max": 50.0,
                                 "min": 30.0
-                            },
-                            "treasure": true
+                            }
                         }
                     ],
                     "name": "minecraft:netherite_chestplate",
@@ -288,8 +281,7 @@
                                 "type": "minecraft:uniform",
                                 "max": 50.0,
                                 "min": 30.0
-                            },
-                            "treasure": true
+                            }
                         }
                     ],
                     "name": "minecraft:netherite_leggings",
@@ -318,8 +310,7 @@
                                 "type": "minecraft:uniform",
                                 "max": 50.0,
                                 "min": 30.0
-                            },
-                            "treasure": true
+                            }
                         }
                     ],
                     "name": "minecraft:netherite_boots",
@@ -340,8 +331,7 @@
                     "functions": [
                         {
                             "function": "minecraft:enchant_with_levels",
-                            "levels": 30.0,
-                            "treasure": true
+                            "levels": 30.0
                         }
                     ],
                     "name": "minecraft:book"

--- a/src/main/resources/data/dungeonz/loot_table/chests/dark_dungeon_normal_boss_loot.json
+++ b/src/main/resources/data/dungeonz/loot_table/chests/dark_dungeon_normal_boss_loot.json
@@ -49,8 +49,7 @@
                                 "type": "minecraft:uniform",
                                 "max": 50.0,
                                 "min": 30.0
-                            },
-                            "treasure": true
+                            }
                         }
                     ],
                     "name": "minecraft:diamond_sword",
@@ -79,8 +78,7 @@
                                 "type": "minecraft:uniform",
                                 "max": 50.0,
                                 "min": 30.0
-                            },
-                            "treasure": true
+                            }
                         }
                     ],
                     "name": "minecraft:diamond_shovel",
@@ -109,8 +107,7 @@
                                 "type": "minecraft:uniform",
                                 "max": 50.0,
                                 "min": 30.0
-                            },
-                            "treasure": true
+                            }
                         }
                     ],
                     "name": "minecraft:diamond_pickaxe",
@@ -139,8 +136,7 @@
                                 "type": "minecraft:uniform",
                                 "max": 50.0,
                                 "min": 30.0
-                            },
-                            "treasure": true
+                            }
                         }
                     ],
                     "name": "minecraft:diamond_axe",
@@ -169,8 +165,7 @@
                                 "type": "minecraft:uniform",
                                 "max": 50.0,
                                 "min": 30.0
-                            },
-                            "treasure": true
+                            }
                         }
                     ],
                     "name": "minecraft:diamond_hoe",
@@ -199,8 +194,7 @@
                                 "type": "minecraft:uniform",
                                 "max": 50.0,
                                 "min": 30.0
-                            },
-                            "treasure": true
+                            }
                         }
                     ],
                     "name": "minecraft:diamond_helmet",
@@ -229,8 +223,7 @@
                                 "type": "minecraft:uniform",
                                 "max": 50.0,
                                 "min": 30.0
-                            },
-                            "treasure": true
+                            }
                         }
                     ],
                     "name": "minecraft:diamond_chestplate",
@@ -259,8 +252,7 @@
                                 "type": "minecraft:uniform",
                                 "max": 50.0,
                                 "min": 30.0
-                            },
-                            "treasure": true
+                            }
                         }
                     ],
                     "name": "minecraft:diamond_leggings",
@@ -289,8 +281,7 @@
                                 "type": "minecraft:uniform",
                                 "max": 50.0,
                                 "min": 30.0
-                            },
-                            "treasure": true
+                            }
                         }
                     ],
                     "name": "minecraft:diamond_boots",
@@ -311,8 +302,7 @@
                     "functions": [
                         {
                             "function": "minecraft:enchant_with_levels",
-                            "levels": 30.0,
-                            "treasure": true
+                            "levels": 30.0
                         }
                     ],
                     "name": "minecraft:book"

--- a/src/main/resources/data/dungeonz/loot_table/chests/temple_dungeon_easy_boss_loot.json
+++ b/src/main/resources/data/dungeonz/loot_table/chests/temple_dungeon_easy_boss_loot.json
@@ -42,8 +42,7 @@
                 "type": "minecraft:uniform",
                 "max": 50.0,
                 "min": 30.0
-              },
-              "treasure": true
+              }
             }
           ],
           "name": "minecraft:iron_sword",
@@ -72,8 +71,7 @@
                 "type": "minecraft:uniform",
                 "max": 50.0,
                 "min": 30.0
-              },
-              "treasure": true
+              }
             }
           ],
           "name": "minecraft:iron_shovel",
@@ -102,8 +100,7 @@
                 "type": "minecraft:uniform",
                 "max": 50.0,
                 "min": 30.0
-              },
-              "treasure": true
+              }
             }
           ],
           "name": "minecraft:iron_pickaxe",
@@ -132,8 +129,7 @@
                 "type": "minecraft:uniform",
                 "max": 50.0,
                 "min": 30.0
-              },
-              "treasure": true
+              }
             }
           ],
           "name": "minecraft:iron_axe",
@@ -162,8 +158,7 @@
                 "type": "minecraft:uniform",
                 "max": 50.0,
                 "min": 30.0
-              },
-              "treasure": true
+              }
             }
           ],
           "name": "minecraft:iron_hoe",
@@ -192,8 +187,7 @@
                 "type": "minecraft:uniform",
                 "max": 50.0,
                 "min": 30.0
-              },
-              "treasure": true
+              }
             }
           ],
           "name": "minecraft:iron_helmet",
@@ -222,8 +216,7 @@
                 "type": "minecraft:uniform",
                 "max": 50.0,
                 "min": 30.0
-              },
-              "treasure": true
+              }
             }
           ],
           "name": "minecraft:iron_chestplate",
@@ -252,8 +245,7 @@
                 "type": "minecraft:uniform",
                 "max": 50.0,
                 "min": 30.0
-              },
-              "treasure": true
+              }
             }
           ],
           "name": "minecraft:iron_leggings",
@@ -282,8 +274,7 @@
                 "type": "minecraft:uniform",
                 "max": 50.0,
                 "min": 30.0
-              },
-              "treasure": true
+              }
             }
           ],
           "name": "minecraft:iron_boots",
@@ -304,8 +295,7 @@
           "functions": [
             {
               "function": "minecraft:enchant_with_levels",
-              "levels": 30.0,
-              "treasure": true
+              "levels": 30.0
             }
           ],
           "name": "minecraft:book"

--- a/src/main/resources/data/dungeonz/loot_table/chests/temple_dungeon_extreme_boss_loot.json
+++ b/src/main/resources/data/dungeonz/loot_table/chests/temple_dungeon_extreme_boss_loot.json
@@ -38,10 +38,10 @@
           "weight": 5,
           "functions": [
             {
-              "enchantments": [
+              "function": "minecraft:enchant_randomly",
+              "options": [
                 "minecraft:mending"
-              ],
-              "function": "minecraft:enchant_randomly"
+              ]
             }
           ]
         }
@@ -78,8 +78,7 @@
                 "type": "minecraft:uniform",
                 "max": 50.0,
                 "min": 30.0
-              },
-              "treasure": true
+              }
             }
           ],
           "name": "minecraft:netherite_sword",
@@ -108,8 +107,7 @@
                 "type": "minecraft:uniform",
                 "max": 50.0,
                 "min": 30.0
-              },
-              "treasure": true
+              }
             }
           ],
           "name": "minecraft:netherite_shovel",
@@ -138,8 +136,7 @@
                 "type": "minecraft:uniform",
                 "max": 50.0,
                 "min": 30.0
-              },
-              "treasure": true
+              }
             }
           ],
           "name": "minecraft:netherite_pickaxe",
@@ -168,8 +165,7 @@
                 "type": "minecraft:uniform",
                 "max": 50.0,
                 "min": 30.0
-              },
-              "treasure": true
+              }
             }
           ],
           "name": "minecraft:netherite_axe",
@@ -198,8 +194,7 @@
                 "type": "minecraft:uniform",
                 "max": 50.0,
                 "min": 30.0
-              },
-              "treasure": true
+              }
             }
           ],
           "name": "minecraft:netherite_hoe",
@@ -228,8 +223,7 @@
                 "type": "minecraft:uniform",
                 "max": 50.0,
                 "min": 30.0
-              },
-              "treasure": true
+              }
             }
           ],
           "name": "minecraft:netherite_helmet",
@@ -258,8 +252,7 @@
                 "type": "minecraft:uniform",
                 "max": 50.0,
                 "min": 30.0
-              },
-              "treasure": true
+              }
             }
           ],
           "name": "minecraft:netherite_chestplate",
@@ -288,8 +281,7 @@
                 "type": "minecraft:uniform",
                 "max": 50.0,
                 "min": 30.0
-              },
-              "treasure": true
+              }
             }
           ],
           "name": "minecraft:netherite_leggings",
@@ -318,8 +310,7 @@
                 "type": "minecraft:uniform",
                 "max": 50.0,
                 "min": 30.0
-              },
-              "treasure": true
+              }
             }
           ],
           "name": "minecraft:netherite_boots",
@@ -340,8 +331,7 @@
           "functions": [
             {
               "function": "minecraft:enchant_with_levels",
-              "levels": 30.0,
-              "treasure": true
+              "levels": 30.0
             }
           ],
           "name": "minecraft:book"
@@ -361,8 +351,7 @@
           "functions": [
             {
               "function": "minecraft:enchant_with_levels",
-              "levels": 30.0,
-              "treasure": false
+              "levels": 30.0
             }
           ],
           "name": "minecraft:book"

--- a/src/main/resources/data/dungeonz/loot_table/chests/temple_dungeon_hard_boss_loot.json
+++ b/src/main/resources/data/dungeonz/loot_table/chests/temple_dungeon_hard_boss_loot.json
@@ -38,10 +38,10 @@
           "weight": 1,
           "functions": [
             {
-              "enchantments": [
+              "function": "minecraft:enchant_randomly",
+              "options": [
                 "minecraft:mending"
-              ],
-              "function": "minecraft:enchant_randomly"
+              ]
             }
           ]
         }
@@ -78,8 +78,7 @@
                 "type": "minecraft:uniform",
                 "max": 50.0,
                 "min": 30.0
-              },
-              "treasure": true
+              }
             }
           ],
           "name": "minecraft:netherite_sword",
@@ -108,8 +107,7 @@
                 "type": "minecraft:uniform",
                 "max": 50.0,
                 "min": 30.0
-              },
-              "treasure": true
+              }
             }
           ],
           "name": "minecraft:netherite_shovel",
@@ -138,8 +136,7 @@
                 "type": "minecraft:uniform",
                 "max": 50.0,
                 "min": 30.0
-              },
-              "treasure": true
+              }
             }
           ],
           "name": "minecraft:netherite_pickaxe",
@@ -168,8 +165,7 @@
                 "type": "minecraft:uniform",
                 "max": 50.0,
                 "min": 30.0
-              },
-              "treasure": true
+              }
             }
           ],
           "name": "minecraft:netherite_axe",
@@ -198,8 +194,7 @@
                 "type": "minecraft:uniform",
                 "max": 50.0,
                 "min": 30.0
-              },
-              "treasure": true
+              }
             }
           ],
           "name": "minecraft:netherite_hoe",
@@ -228,8 +223,7 @@
                 "type": "minecraft:uniform",
                 "max": 50.0,
                 "min": 30.0
-              },
-              "treasure": true
+              }
             }
           ],
           "name": "minecraft:netherite_helmet",
@@ -258,8 +252,7 @@
                 "type": "minecraft:uniform",
                 "max": 50.0,
                 "min": 30.0
-              },
-              "treasure": true
+              }
             }
           ],
           "name": "minecraft:netherite_chestplate",
@@ -288,8 +281,7 @@
                 "type": "minecraft:uniform",
                 "max": 50.0,
                 "min": 30.0
-              },
-              "treasure": true
+              }
             }
           ],
           "name": "minecraft:netherite_leggings",
@@ -318,8 +310,7 @@
                 "type": "minecraft:uniform",
                 "max": 50.0,
                 "min": 30.0
-              },
-              "treasure": true
+              }
             }
           ],
           "name": "minecraft:netherite_boots",
@@ -340,8 +331,7 @@
           "functions": [
             {
               "function": "minecraft:enchant_with_levels",
-              "levels": 30.0,
-              "treasure": true
+              "levels": 30.0
             }
           ],
           "name": "minecraft:book"

--- a/src/main/resources/data/dungeonz/loot_table/chests/temple_dungeon_normal_boss_loot.json
+++ b/src/main/resources/data/dungeonz/loot_table/chests/temple_dungeon_normal_boss_loot.json
@@ -49,8 +49,7 @@
                 "type": "minecraft:uniform",
                 "max": 50.0,
                 "min": 30.0
-              },
-              "treasure": true
+              }
             }
           ],
           "name": "minecraft:diamond_sword",
@@ -79,8 +78,7 @@
                 "type": "minecraft:uniform",
                 "max": 50.0,
                 "min": 30.0
-              },
-              "treasure": true
+              }
             }
           ],
           "name": "minecraft:diamond_shovel",
@@ -109,8 +107,7 @@
                 "type": "minecraft:uniform",
                 "max": 50.0,
                 "min": 30.0
-              },
-              "treasure": true
+              }
             }
           ],
           "name": "minecraft:diamond_pickaxe",
@@ -139,8 +136,7 @@
                 "type": "minecraft:uniform",
                 "max": 50.0,
                 "min": 30.0
-              },
-              "treasure": true
+              }
             }
           ],
           "name": "minecraft:diamond_axe",
@@ -169,8 +165,7 @@
                 "type": "minecraft:uniform",
                 "max": 50.0,
                 "min": 30.0
-              },
-              "treasure": true
+              }
             }
           ],
           "name": "minecraft:diamond_hoe",
@@ -199,8 +194,7 @@
                 "type": "minecraft:uniform",
                 "max": 50.0,
                 "min": 30.0
-              },
-              "treasure": true
+              }
             }
           ],
           "name": "minecraft:diamond_helmet",
@@ -229,8 +223,7 @@
                 "type": "minecraft:uniform",
                 "max": 50.0,
                 "min": 30.0
-              },
-              "treasure": true
+              }
             }
           ],
           "name": "minecraft:diamond_chestplate",
@@ -259,8 +252,7 @@
                 "type": "minecraft:uniform",
                 "max": 50.0,
                 "min": 30.0
-              },
-              "treasure": true
+              }
             }
           ],
           "name": "minecraft:diamond_leggings",
@@ -289,8 +281,7 @@
                 "type": "minecraft:uniform",
                 "max": 50.0,
                 "min": 30.0
-              },
-              "treasure": true
+              }
             }
           ],
           "name": "minecraft:diamond_boots",
@@ -311,8 +302,7 @@
           "functions": [
             {
               "function": "minecraft:enchant_with_levels",
-              "levels": 30.0,
-              "treasure": true
+              "levels": 30.0
             }
           ],
           "name": "minecraft:book"


### PR DESCRIPTION
All loot tables now use the correct 1.21.1 format and should no longer create inconsistent enchanted items.